### PR TITLE
feat(#347): K8s 集群同步时自动清理已移除节点

### DIFF
--- a/backend/src/main/java/com/lab/k8s/K8sClusterService.java
+++ b/backend/src/main/java/com/lab/k8s/K8sClusterService.java
@@ -183,6 +183,36 @@ public class K8sClusterService {
                 }
             }
 
+            // 清理 K8s 中已不存在的节点
+            List<ComputeNode> existingK8sNodes = nodeRepo.findByClusterId(cluster.getId());
+            Set<String> currentK8sNodeKeys = new HashSet<>();
+            for (Map<String, String> n : k8sNodes) {
+                String ip = n.get("ip");
+                String name = n.get("name");
+                if (ip != null) currentK8sNodeKeys.add("ip:" + ip);
+                if (name != null) currentK8sNodeKeys.add("name:" + cluster.getName() + "/" + name);
+            }
+
+            int removed = 0;
+            for (ComputeNode existing : existingK8sNodes) {
+                boolean stillExists = false;
+                if (existing.getIpAddress() != null) {
+                    stillExists = currentK8sNodeKeys.contains("ip:" + existing.getIpAddress());
+                }
+                if (!stillExists && existing.getName() != null) {
+                    stillExists = currentK8sNodeKeys.contains("name:" + existing.getName());
+                }
+                if (!stillExists) {
+                    log.info("Removing stale K8s node: {} (IP: {}) - no longer in cluster {}",
+                            existing.getName(), existing.getIpAddress(), cluster.getName());
+                    nodeRepo.delete(existing);
+                    removed++;
+                }
+            }
+            if (removed > 0) {
+                log.info("Cleaned up {} stale nodes from cluster {}", removed, cluster.getName());
+            }
+
             List<ComputeNode> clusterNodes = nodeRepo.findByClusterId(cluster.getId());
             cluster.setNodeCount(clusterNodes.size());
             cluster.setOnlineCount((int) clusterNodes.stream()
@@ -196,6 +226,7 @@ public class K8sClusterService {
             result.put("totalNodes", k8sNodes.size());
             result.put("added", added);
             result.put("updated", updated);
+            result.put("removed", removed);
             result.put("clusterNodeCount", cluster.getNodeCount());
         } catch (Exception e) {
             log.error("同步集群节点失败: {}", e.getMessage(), e);
@@ -449,28 +480,16 @@ public class K8sClusterService {
     }
 
     /**
-     * 定时同步集群节点计数
+     * 定时同步集群节点（包含发现新节点和清理已移除节点）
      */
     @Scheduled(fixedRate = 60000)
-    @Transactional
     public void syncClusterNodeCounts() {
         List<K8sCluster> clusters = clusterRepo.findByStatus(K8sCluster.STATUS_READY);
         for (K8sCluster cluster : clusters) {
             try {
-                List<ComputeNode> clusterNodes = nodeRepo.findByClusterId(cluster.getId());
-                int total = clusterNodes.size();
-                int online = (int) clusterNodes.stream()
-                        .filter(n -> n.getStatus() == ComputeNode.Status.ONLINE
-                                || n.getStatus() == ComputeNode.Status.BUSY)
-                        .count();
-                if (!Objects.equals(cluster.getNodeCount(), total)
-                        || !Objects.equals(cluster.getOnlineCount(), online)) {
-                    cluster.setNodeCount(total);
-                    cluster.setOnlineCount(online);
-                    clusterRepo.save(cluster);
-                }
+                syncNodes(cluster.getId());
             } catch (Exception e) {
-                log.warn("同步集群 {} 节点计数失败: {}", cluster.getName(), e.getMessage());
+                log.warn("Failed to sync cluster {}: {}", cluster.getName(), e.getMessage());
             }
         }
     }


### PR DESCRIPTION
## 变更内容

### 问题
K8s 集群同步时只会发现和更新节点，不会清理已经从集群中移除的节点。导致平台上残留幽灵节点。

### 解决方案
在 `syncNodes()` 方法中添加了清理逻辑：

1. **检测陈旧节点** — 同步后对比数据库中的节点与 K8s 实际节点
   - 使用 IP + 名称双重匹配，避免误删
2. **自动删除** — 不在 K8s 集群中的节点自动从数据库移除
3. **日志记录** — 每次清理都有详细日志
4. **定时任务升级** — `syncClusterNodeCounts` 改为调用完整 `syncNodes()`，每分钟执行一次完整同步（包含清理）

### API 响应变化
`POST /api/k8s/clusters/{id}/sync` 返回新增 `removed` 字段：
```json
{
  "success": true,
  "totalNodes": 1,
  "added": 0,
  "updated": 1,
  "removed": 0,
  "clusterNodeCount": 1
}
```

### 测试
- ✅ 构建成功
- ✅ 后端启动正常
- ✅ Sync API 返回包含 removed 字段
- ✅ 部署到开发环境验证通过

Closes #347